### PR TITLE
Fix data loader native method call

### DIFF
--- a/componentes/tabela_virtual/js/data-loader.js
+++ b/componentes/tabela_virtual/js/data-loader.js
@@ -165,6 +165,11 @@ class DataLoader {
     }
   }
 
+  // Alias para retrocompatibilidade
+  async loadDataNative(questionId, filtros) {
+    return this.loadDataNativePerformance(questionId, filtros);
+  }
+
   getStats() {
     return {
       isLoading: this.isLoading,

--- a/componentes/tabela_virtual/js/main.js
+++ b/componentes/tabela_virtual/js/main.js
@@ -150,7 +150,11 @@ class App {
     try {
       if (useNativeAPI) {
         // Usa API Native (muito mais rápido!)
-        dados = await dataLoader.loadDataNative(this.questionId, filtros, 'dataset');
+        // Ajustado para o novo método loadDataNativePerformance
+        dados = await dataLoader.loadDataNativePerformance(
+          this.questionId,
+          filtros
+        );
       } else {
         // Método antigo (Query direta)
         dados = await dataLoader.loadWithRetry(this.questionId, filtros);


### PR DESCRIPTION
## Summary
- use `loadDataNativePerformance` in main.js
- add backward-compatible alias `loadDataNative` in data-loader

## Testing
- `./test.sh <<'EOF'
all
EOF` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: environment lacks internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6866d9dee034832abb2eda10447647ca